### PR TITLE
fit with aspect ratios

### DIFF
--- a/jquery.cycle.all.js
+++ b/jquery.cycle.all.js
@@ -272,10 +272,28 @@ function buildOptions($cont, $slides, els, options, o) {
 	removeFilter(els[first], opts);
 
 	// stretch slides
-	if (opts.fit && opts.width)
-		$slides.width(opts.width);
-	if (opts.fit && opts.height && opts.height != 'auto')
-		$slides.height(opts.height);
+	if (opts.fit) {
+		if (!opts.aspect) {
+		        if (opts.width)
+		            $slides.width(opts.width);
+		        if (opts.height && opts.height != 'auto')
+		            $slides.height(opts.height);
+		} else {
+			$slides.each(function(){
+				var $slide = $(this);
+				var ratio = (opts.aspect === true) ? $slide.width()/$slide.height() : opts.aspect;
+				if( opts.width && $slide.width() != opts.width ) {
+					$slide.width( opts.width );
+					$slide.height( opts.width / ratio );
+				}
+
+				if( opts.height && $slide.height() < opts.height ) {
+					$slide.height( opts.height );
+					$slide.width( opts.height * ratio );
+				}
+			});
+		}
+	}
 
 	// stretch container
 	var reshape = opts.containerResize && !$cont.innerHeight();
@@ -891,6 +909,7 @@ $.fn.cycle.defaults = {
 	end:		   null,  // callback invoked when the slideshow terminates (use with autostop or nowrap options): function(options)
 	fastOnEvent:   0,	  // force fast transitions when triggered manually (via pager or prev/next); value == time in ms
 	fit:		   0,	  // force slides to fit container
+	aspect:		   false  // preserve aspect ratio during "fit", cropping if necessary
 	fx:			  'fade', // name of transition effect (or comma separated names, ex: 'fade,scrollUp,shuffle')
 	fxFn:		   null,  // function used to control the transition: function(currSlideElement, nextSlideElement, options, afterCalback, forwardFlag)
 	height:		  'auto', // container height

--- a/jquery.cycle.all.js
+++ b/jquery.cycle.all.js
@@ -295,6 +295,20 @@ function buildOptions($cont, $slides, els, options, o) {
 		}
 	}
 
+	if (opts.center && ((!opts.fit) || opts.aspect)) {
+		$slides.each(function(){
+			var $slide = $(this);
+			$slide.css({
+				"margin-left": opts.width ?
+					((opts.width - $slide.width()) / 2) + "px" :
+					0,
+				"margin-top": opts.height ?
+					((opts.height - $slide.height()) / 2) + "px" :
+					0
+			});
+		});
+	}
+
 	// stretch container
 	var reshape = opts.containerResize && !$cont.innerHeight();
 	if (reshape) { // do this only if container has no size http://tinyurl.com/da2oa9
@@ -910,6 +924,7 @@ $.fn.cycle.defaults = {
 	fastOnEvent:   0,	  // force fast transitions when triggered manually (via pager or prev/next); value == time in ms
 	fit:		   0,	  // force slides to fit container
 	aspect:		   false  // preserve aspect ratio during "fit", cropping if necessary
+	center:		   false  // center the image. doesn't make sense with "fit" unless "aspect" is also given
 	fx:			  'fade', // name of transition effect (or comma separated names, ex: 'fade,scrollUp,shuffle')
 	fxFn:		   null,  // function used to control the transition: function(currSlideElement, nextSlideElement, options, afterCalback, forwardFlag)
 	height:		  'auto', // container height


### PR DESCRIPTION
I've made a couple of changes to allow "fit" to optionally preserve aspect-ratio.

I did these changes in "cycle.lite.1.1.js", then ported them over to cycle.all since I couldn't find a branch for just the "lite" part. The makes it highly likely that there are bugs here, since I didn't bother to thoroughly test the .all version.

It also "crops when necessary", which is fine for my needs, but may not be universally desired.

In summary: this probably needs work prior to inclusion. I'm willing to do that extra work if necessary, but I figured a pull request was a good way to find out 1) if it really is necessary, and 2) if there's any chance of getting this feature added in the first place.

I release these changes under the MIT and GPL licenses as required.
