### PR TITLE
Added 'scaling' option to omit image scaling (stretching) of images when the 'fit' and 'aspect' options are set

### DIFF
--- a/jquery.cycle.all.js
+++ b/jquery.cycle.all.js
@@ -306,7 +306,7 @@ function buildOptions($cont, $slides, els, options, o) {
 	$(els[first]).css('opacity',1).show(); // opacity bit needed to handle restart use case
 	removeFilter(els[first], opts);
 
-	// stretch slides
+	// fit (and optionally stretch) slides into the container
 	if (opts.fit) {
 		if (!opts.aspect) {
 	        if (opts.width)
@@ -316,16 +316,32 @@ function buildOptions($cont, $slides, els, options, o) {
 		} else {
 			$slides.each(function(){
 				var $slide = $(this);
-				var ratio = (opts.aspect === true) ? $slide.width()/$slide.height() : opts.aspect;
-				if( opts.width && $slide.width() != opts.width ) {
-					$slide.width( opts.width );
-					$slide.height( opts.width / ratio );
-				}
+                var slide_width = $slide.width();
+                var slide_height = $slide.height();
+                var cont_width = $cont.width();
+                var cont_height = $cont.height();
+				var ratio = (opts.aspect === true) ? slide_width/slide_height : opts.aspect;
 
-				if( opts.height && $slide.height() < opts.height ) {
-					$slide.height( opts.height );
-					$slide.width( opts.height * ratio );
-				}
+                if (slide_width != cont_width) {
+                    if (slide_width > cont_width) {
+                         $slide.width(slide_width=cont_width);
+                    }
+                    else if (opts.scaling !== false) {
+                         $slide.width(slide_width=cont_width);
+                    }
+
+                     $slide.height(slide_height=slide_width/ratio);
+                }
+
+                if (slide_height != cont_height) {
+                    if (slide_height > cont_height) {
+                         $slide.height(slide_height=cont_height);
+                    }
+                    else if (opts.scaling !== false) {
+                         $slide.height(slide_height=cont_height);
+                    }
+                    $slide.width(slide_width=slide_height*ratio);    
+                }
 			});
 		}
 	}


### PR DESCRIPTION
Added new option called 'scaling'. When this option is set to true, as well as the "fit" and "aspect" options, slides are never scaled (stretched). Instead, slides are always shrunk to fit into the container while maintaining the same aspect ratio.

I think it's common for users not to desire scaling, as it can make images blurry. With the scaling option, we can simulate Galleria's behavior when the maxScaleRatio option is used by setting the following options:

{
  fit: true,
  aspect: true.
  scaling: false,
  slideResize: false
}

I didn't add my changes to jquery.cycle.lite as I noticed that wpalmer's changes weren't there either.

Note, if you'd rather call the option "stretching" instead of "scaling" that's fine, as I wouldn't want it to be confused with interpolation algorithms.

Cheers,
Mike
