### PR TITLE
Check if opts is set in triggerPause

### DIFF
--- a/jquery.cycle.all.js
+++ b/jquery.cycle.all.js
@@ -101,6 +101,10 @@ $.fn.cycle = function(options, arg2) {
 
 function triggerPause(cont, byHover, onPager) {
 	var opts = $(cont).data('cycle.opts');
+	if(!opts){
+	 log('Options not found, "pause" ignored');
+	 return false;
+	}
 	var paused = !!cont.cyclePause;
 	if (paused && opts.paused)
 		opts.paused(cont, opts, byHover, onPager);


### PR DESCRIPTION
Just added a !opts conditional in triggerPause. Otherwise, I was getting this in a few instances:

> Cannot read property 'paused' of undefined - jquery.cycle.all.js:105
